### PR TITLE
Fixing bug -> caused by missing return types attributes

### DIFF
--- a/DruidsCornerAPI/DruidsCornerAPI/Controllers/ResourcesController.cs
+++ b/DruidsCornerAPI/DruidsCornerAPI/Controllers/ResourcesController.cs
@@ -38,8 +38,7 @@ namespace DruidsCornerAPI.Controllers
         ///     Image source (buffered stream), or NotFoundError(404)
         /// </returns>
         [HttpGet("image", Name = "Fetches beer's image")]
-        [ProducesResponseType(500)]
-        [Produces("application/octet-stream")]
+        [Produces("application/octet-stream", "application/json")]
         [ProducesResponseType(typeof(FileStreamResult), 200)]
         public async Task<IActionResult> FetchSingleImage([FromQuery] uint number)
         {
@@ -69,7 +68,7 @@ namespace DruidsCornerAPI.Controllers
         ///     Pdf page source, buffered stream or NotFoundError(404)
         /// </returns>
         [HttpGet("pdf", Name = "Fetches beer's pdf page")]
-        [Produces("application/octet-stream")]
+        [Produces("application/octet-stream", "application/json")]
         [ProducesResponseType(typeof(FileStreamResult), 200)]
         public async Task<IActionResult> FetchSinglePdf([FromQuery] uint number)
         {


### PR DESCRIPTION
Fixing wrong return status (406) when it should be 404 (in case of a wrong recipe number being queried).

Closes #15 